### PR TITLE
migrate RFP PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rfp_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rfp_pr_template.md
@@ -1,0 +1,18 @@
+# Request for Proposals
+
+## Abstract
+
+> Provide a brief description of your idea here (1-2 paragraphs).
+>
+> The details should be in the RFP document that is being added to the repository via this pull request.
+
+
+## Background
+
+> Feel free to provide further information that you find relevant and didn't fit into the RFP template here.
+
+
+## Checklist
+
+- [ ] I have checked the [open](https://github.com/w3f/General-Grants-Program/tree/master/rfps) and [implemented](https://github.com/w3f/General-Grants-Program/tree/master/rfps/implemented) RFPs to make sure this is not a duplicate.
+- [ ] I have read and followed the [RFP Suggestion instructions](https://github.com/w3f/General-Grants-Program#mailbox_with_mail-request-for-proposals-rfp-suggestions).


### PR DESCRIPTION
this template was missing: https://github.com/w3f/General-Grants-Program/blob/master/.github/PULL_REQUEST_TEMPLATE/rfp_pr_template.md