### PR TITLE
add markdownlint settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.markdownlint": true
+        "source.fixAll.markdownlint": false
     },
     "markdownlint.config": {
         "default": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": true
+    },
+    "markdownlint.config": {
+        "default": true,
+        "MD003": { "style": "atx"},
+        "MD004": { "style": "dash"},
+        "MD007": { "indent": 2},
+        "MD012": false,
+        "MD024": { "siblings_only": true },
+        "MD026": false,
+        "MD033": false,
+        "MD034": false
+    },
+    "markdownlint.run": "onSave"
+}


### PR DESCRIPTION
This PR adds a file that overrides VSCode user settings. I think this is generally handy as long as the majority uses vscode. But in this case, they are rules for the extension [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint). 

This should prevent our linters from fighting.