### PR TITLE
Remove the word "maintenance" from Crossbow

### DIFF
--- a/applications/crossbow.md
+++ b/applications/crossbow.md
@@ -1,4 +1,4 @@
-# W3F Maintenance Grant Proposal
+# W3F Grant Proposal
 
 - **Project Code Name:** Crossbow (formerly `Creator`)
 - **Team Name:** DodoRare, Inc.


### PR DESCRIPTION
to avoid confusion in the future and for external readers