### PR TITLE
Milestone delivery amendment, remove CLI from deliverables

### DIFF
--- a/applications/MIXERv2.md
+++ b/applications/MIXERv2.md
@@ -147,9 +147,9 @@ Definitions: Secret Key(S), Public key(P), Nullifier (N), Leaf(L), Hash function
 | 0a. | License | Apache 2.0 / MIT / Unlicense |
 | 0b. | Documentation | We will provide both inline documentation of the code and a basic tutorial that explains how a user can (for example) spin up one of our Substrate nodes. Once the node is up, it will be possible to send test transactions that will show how the new functionality works. |
 | 1. | Relayer in Rust | We will build a transaction relayer that supports the relaying transactions for a fee and add support for these new pallets. |
-| 2. | CLI in Rust | We will build out a Rust based CLI for interacting with the mixer |
-| 2a. | CLI Support: Note storage | Creation and storage of deposit notes handled by the CLI |
-| 2b. | CLI Support: Note spending | Proof generation and transaction submission to relayers or directly to the chain handled by the CLI. |
+| ~~2.~~ | ~~CLI in Rust~~ | ~~We will build out a Rust based CLI for interacting with the mixer~~ |
+| ~~2a.~~ | ~~CLI Support: Note storage~~ | ~~Creation and storage of deposit notes handled by the CLI~~ |
+| ~~2b.~~ | ~~CLI Support: Note spending~~ | ~~Proof generation and transaction submission to relayers or directly to the chain handled by the CLI.~~ |
 | 3. | WASM bindings | We will build out necessary WASM compatible proof generation code to be reused in the browser for dApp support. |
 | 3a. | WASM bindings: Web Worker support | We will build out a pipeline for integrating this logic into web workers. |
 | 4. | UI Support: Multi-Asset support | We will build out multi-asset support in our UI for mixers of arbitrary token types. |


### PR DESCRIPTION
Amendment for delivery

### Project Abstract
Amending the extended mixer since all deliverables except CLI are ready. The CLI would take additional time and this has taken far longer than 1 month to complete. We would consider building out a CLI but don't want to waste time spent delivering this larger than expected deliverable.

### For which grant [level](https://github.com/w3f/Grants-Program#level_slider-levels) are you applying? 
- [ ] **Level 1**:  Up to $10,000, 2 approvals
- [x] **Level 2**:  Up to $50,000, 3 approvals
- [ ] **Level 3**:  Unlimited, 5 approvals (for > $100k Web3 Foundation Council approval)

### Application Checklist

- [x] The [application template](https://github.com/w3f/Grants-Program/blob/master/applications/application-template.md) has been copied, renamed ( `project_name.md`) and updated.
- [x] A BTC or Ethereum (DAI/USDT) address for the payment of the milestones is provided inside the application.
- [x] I have read and acknowledged the [terms and conditions](https://github.com/w3f/Grants-Program/blob/master/docs/T&Cs.md).
- [x] The software delivered for this grant will be released under an open-source license specified in the application.
- [x] The initial PR contains only one commit (squash and force-push if needed).
- [x] The grant will only be announced once the first milestone [has been accepted](https://github.com/w3f/Grant-Milestone-Delivery#process).
