### PR TITLE
Change the scope of work of the 5th milestone in OpenBrush

### DIFF
--- a/applications/openbrush-follow-up.md
+++ b/applications/openbrush-follow-up.md
@@ -242,14 +242,14 @@ PSP - https://github.com/w3f/PSPs/pull/25
 * **FTE:**  2
 * **Costs:** 15,000 USD
 
-| Number | Deliverable                                                              | Specification                                                                                                                             |
-| -----  | -----------                                                              | -------------                                                                                                                             |
-| 0a.    | License                                                                  | MIT                                                                                                                                       |
-| 0b.    | Documentation                                                            | We will provide inline documentation, example of usage of extensions. |
-| 0c.    | Testing Guide                                                            | We will add tests for extensions and for a new changes from ink! side.                                                           |
-| 1.     | Contribute to ink! with fixing of events                                 | We will help to fix the [issue](https://github.com/paritytech/ink/issues/809) with events. |
-| 2.     | Add support of default implementation in trait definition on ink! level  | We will help with the support of default implementation inside of trait definition. It will require discussions with the ink! team to define the best way how to implement that without conflicts with their future changes.  |
-| 3.     | Refactor of implementation according changes in ink!                     | After changes in ink! we will refactor the code of library.  |
+| Number | Deliverable                                          | Specification                                                                              |
+| -----  |------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| 0a.    | License                                              | MIT                                                                                        |
+| 0b.    | Documentation                                        | We will provide inline documentation, example of usage of extensions.                      |
+| 0c.    | Testing Guide                                        | We will add tests for extensions and for a new changes from ink! side.                     |
+| 1.     | Contribute to ink! with fixing of events             | We will help to fix the [issue](https://github.com/paritytech/ink/issues/809) with events. |
+| 2.     | Re-work the storage of contracts                     | We want to resolve the [issue](https://github.com/paritytech/ink/issues/1134).             |
+| 3.     | Refactor of implementation according changes in ink! | After changes in ink! we will refactor the code of library.                                |
 
 ## Future Plans
 


### PR DESCRIPTION
We want to change the scope of work of the 5th milestone in OpenBrush. 
We've changed point 2: "Add support of default implementation in trait definition on ink! level" -> "Re-work the storage of contracts"

We consider that [reworking of the contract's storage](https://github.com/paritytech/ink/issues/1134) should be done before default implementation in traits and it is more important. We participated in the discussion and we have a clear vision of how to implement that.

That change requires the same human resources as default implementation in traits so the cost of the milestone is the same.
We moved default implementation in traits to the third Grant. 