### PR TITLE
Add links to FAQ doc

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,150 +3,150 @@
 # Frequently Asked Questions<!-- omit in toc -->
 
 - [🧭 General](#-general)
+  - [How much can I ask for?](#how-much-can-i-ask-for)
+  - [What activities/positions do you fund?](#what-activitiespositions-do-you-fund)
+  - [Can anyone apply?](#can-anyone-apply)
+  - [Can I get an upfront payment?](#can-i-get-an-upfront-payment)
+  - [When do I get paid?](#when-do-i-get-paid)
+  - [Can I reuse someone else’s open-source code?](#can-i-reuse-someone-elses-open-source-code)
+  - [I am starting a company that [...]. I want to use Polkadot/Kusama/Substrate to build a blockchain/parachain and connect [...]. Would I be eligible for a grant?](#i-am-starting-a-company-that--i-want-to-use-polkadotkusamasubstrate-to-build-a-blockchainparachain-and-connect--would-i-be-eligible-for-a-grant)
+  - [My application was rejected. Do you have any recommendations on where to go from here?](#my-application-was-rejected-do-you-have-any-recommendations-on-where-to-go-from-here)
+  - [One of your grantees is using my code without respecting the terms of its license.](#one-of-your-grantees-is-using-my-code-without-respecting-the-terms-of-its-license)
+  - [Why are other grant applications being accepted faster than mine?](#why-are-other-grant-applications-being-accepted-faster-than-mine)
 - [🖊️ Application Process](#️-application-process)
+  - [How long does it take from application to decision?](#how-long-does-it-take-from-application-to-decision)
+  - [A W3F member approved my application. Does that mean it is accepted?](#a-w3f-member-approved-my-application-does-that-mean-it-is-accepted)
+  - [How do I apply if I want to keep information private or want to be paid in fiat?](#how-do-i-apply-if-i-want-to-keep-information-private-or-want-to-be-paid-in-fiat)
 - [🥳 After Approval](#-after-approval)
+  - [When can I apply for a follow-up grant?](#when-can-i-apply-for-a-follow-up-grant)
+  - [Something came up and I cannot finish the project in time. Can we postpone or call off the rest of my project?](#something-came-up-and-i-cannot-finish-the-project-in-time-can-we-postpone-or-call-off-the-rest-of-my-project)
+  - [Can I list the Web3 Foundation as a partner?](#can-i-list-the-web3-foundation-as-a-partner)
+  - [Can you help me advertise my project?](#can-you-help-me-advertise-my-project)
+  - [I found one of my deliverables to be unnecessary, impossible or already done elsewhere. What do I do?](#i-found-one-of-my-deliverables-to-be-unnecessary-impossible-or-already-done-elsewhere-what-do-i-do)
 - [🚚 Milestone Delivery](#-milestone-delivery)
+  - [How do I submit a milestone?](#how-do-i-submit-a-milestone)
+  - [Can I submit two or more milestones at once?](#can-i-submit-two-or-more-milestones-at-once)
+  - [Can I add a badge to my repo once I’ve completed a milestone?](#can-i-add-a-badge-to-my-repo-once-ive-completed-a-milestone)
+  - [Why are other milestones being accepted or discussed faster than mine?](#why-are-other-milestones-being-accepted-or-discussed-faster-than-mine)
 
 ## 🧭 General
 
-<details>
-  <summary><b>How much can I ask for?</b></summary>
+### How much can I ask for?
 
   Please refer to the [section on grant levels in our README](../README.md#level_slider-levels) for funding limits.
-</details>
 
-<details>
-  <summary><b>What activities/positions do you fund?</b></summary>
+
+### What activities/positions do you fund?
 
   The Web3 Foundation's Grants Program aims to fund software development and research activities that are beneficial for the ecosystem as a whole. As such, we don't usually fund tangential costs such as business-oriented activities (marketing, business planning), events or outreach, and—for non-infrastructure projects—deployment and hosting costs, maintenance or audits. We also expect you to have a good understanding of the technologies you are planning to use, meaning that we don't fund time spent learning how to use Substrate or how to write ink! smart contracts.
-</details>
 
-<details>
-  <summary><b>Can anyone apply?</b></summary>
+
+### Can anyone apply?
 
   Projects for which a token sale has been or is being conducted are not eligible for a Web3 Foundation grant. Other than that, there are no restrictions.
-</details>
 
-<details>
-  <summary><b>Can I get an upfront payment?</b></summary>
+
+### Can I get an upfront payment?
 
   No.
-</details>
 
-<details>
-  <summary><b>When do I get paid?</b></summary>
+
+### When do I get paid?
 
   Payments are issued once a milestone has been successfully delivered. By ‘successful’, we mean that our Grants team has reviewed _and officially accepted_ your submission.
-</details>
 
-<details>
-  <summary><b>Can I reuse someone else’s open-source code?</b></summary>
+
+### Can I reuse someone else’s open-source code?
 
   Open source software and the Web3 movement are all about collaboration. As long as you meet the code’s license, we encourage you to find, modify and contribute to already existing libraries and projects if it is of use for your project. However, we expect you to honour other people’s work and their right to attribution, and your published code to adhere to the license requirements of the code you are benefiting from. Submitting code as part of a milestone that violates someone else’s license will result in immediate termination. We will furthermore continue to monitor any repositories you may have submitted as part of a milestone for possible license infringements and reserve the right to terminate the grant if we find you going out of your way to hide external contributions.
-</details>
 
-<details>
-  <summary><b>I am starting a company that [...]. I want to use Polkadot/Kusama/Substrate to build a blockchain/parachain and connect [...]. Would I be eligible for a grant?</b></summary>
+
+### I am starting a company that [...]. I want to use Polkadot/Kusama/Substrate to build a blockchain/parachain and connect [...]. Would I be eligible for a grant?
 
   What the Web3 Foundation is mainly looking for to support are projects "[driving advancement and adoption of decentralized software protocols [and] that make it easier for developers to build useful applications using these protocols.](https://web3.foundation/grants/)" As such, we do not award grants to individual companies developing their private infrastructure. However, if part of your work is to build a library or another piece of software that could be of interest to the general Polkadot/Kusama/Substrate ecosystem and ask for funding specific to that, we are happy to look into it.
-</details>
 
-<details>
-  <summary><b>My application was rejected. Do you have any recommendations on where to go from here?</b></summary>
+
+### My application was rejected. Do you have any recommendations on where to go from here?
 
   We usually give reasons why an application was rejected. We always try to be constructive and work with you towards an application that is beneficial to all parties. If we find no common ground, please have a look at [this section in our Grants Program readme](https://github.com/w3f/Grants-Program#rocket-alternative-funding-sources) for a list of alternative funding opportunities.
-</details>
 
-<details>
-  <summary><b>One of your grantees is using my code without respecting the terms of its license.</b></summary>
+
+### One of your grantees is using my code without respecting the terms of its license.
 
   Please [reach out to us](mailto:grants@web3.foundation) asap.
-</details>
 
-<details>
-  <summary><b>Why are other grant applications being accepted faster than mine?</b></summary>
+
+### Why are other grant applications being accepted faster than mine?
 
   There are many reasons why your application might take longer than others: some applications are straightforward and simple and address an obvious issue, others require deeper understanding and discussion. If your application is highly technical or specialised, we might have to bring in an external evaluator. Sometimes, this specialised evaluator is busy with another evaluation. And sometimes, the committee is simply unsure or not quite convinced.
-</details>
+
 
 
 ## 🖊️ Application Process
 
-<details>
-  <summary><b>How long does it take from application to decision?</b></summary>
+### How long does it take from application to decision?
 
   Depending on the requested amount, quality of the application and desirability for the ecosystem, a grant application could be approved within a week. Usually, there will be a discussion and requests for changes, additions or improvements. If no one in the committee finds the application approval-worthy or you don't react to our comments, it will be closed after two weeks of inactivity. Very large grants require the approval of the council, which convenes once a month. Thus, once an editor declares your application sufficient, it may take up to one month until a decision is made.
-</details>
 
-<details>
-  <summary><b>A W3F member approved my application. Does that mean it is accepted?</b></summary>
+
+### A W3F member approved my application. Does that mean it is accepted?
 
   Depending on the size of the grant, applications require two to five committee members to approve it. Since we have many different members with different backgrounds and specializations, it is possible that the committee disagrees and your application gets rejected even though one or two members approved it.
   The application is accepted once the pull request is merged.
-</details>
 
-<details>
-  <summary><b>How do I apply if I want to keep information private or want to be paid in fiat?</b></summary>
+
+### How do I apply if I want to keep information private or want to be paid in fiat?
 
   For special cases that do not fit the regular grants structure, we provide [a form](https://docs.google.com/forms/d/e/1FAIpQLSfMfjiRmDQDRk-4OhNASM6BAKii7rz_B1jWtbCPkUh6N7M2ww/viewform). You can provide all application data by submitting this form, or submit the form with a reference to a pull request with data you are willing to make public.
-</details>
+
 
 ## 🥳 After Approval
 
-<details>
-  <summary><b>When can I apply for a follow-up grant?</b></summary>
+### When can I apply for a follow-up grant?
 
   Anyone who has successfully completed a grant project (i.e. all milestones were accepted, or the previous grant was terminated in mutual agreement) can apply for a follow-up grant. Concurrent grants are only granted in special circumstances.
-</details>
 
-<details>
-  <summary><b>Something came up and I cannot finish the project in time. Can we postpone or call off the rest of my project?</b></summary>
+
+### Something came up and I cannot finish the project in time. Can we postpone or call off the rest of my project?
 
   The Web3 Foundation reserves the right to terminate an agreement that is behind schedule. However, we are not interested in taking away your grant for any slight hiccup. More often than not, delays are part of the journey and do not constitute a reason for concern. The best way to handle changes in your plans is to get in touch with us. If you would like to prematurely end your work, we can amend your application and remove the milestones you won't be able to complete. If you decide to continue work at a later date, you can always reapply for the remaining milestones and potentially adapt them to take into account any insights you have gained in the meantime.
-</details>
 
-<details>
-  <summary><b>Can I list the Web3 Foundation as a partner?</b></summary>
+
+### Can I list the Web3 Foundation as a partner?
 
   No. Once the grants team has accepted your first milestone, you may display our [grants badge](https://github.com/w3f/Grants-Program/blob/master/docs/grant-badge-guidelines.md) in a project-specific context, such as the repository containing the grant project work.
-</details>
 
-<details>
-  <summary><b>Can you help me advertise my project?</b></summary>
+
+### Can you help me advertise my project?
 
   The Web3 Foundation does not provide PR services to its grantees. However, once per month we co-promote announcements from grants that have delivered a milestone on [Twitter](https://twitter.com/Web3foundation). Note that the milestone needs to have been accepted prior to the announcement. Lastly, please observe our [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/announcement-guidelines.md) for all grant-related communications. This document also lists an email address through which you can get in touch with our PR team for feedback and in case you have specific questions.
-</details>
 
-<details>
-  <summary><b>I found one of my deliverables to be unnecessary, impossible or already done elsewhere. What do I do?</b></summary>
+
+### I found one of my deliverables to be unnecessary, impossible or already done elsewhere. What do I do?
 
   Plans change. If you find parts of your original grant application to be unnecessary or you decide to pivot, but you still want to finish the project: get in touch with us. If your new plans are in line with the Web3 Foundation’s values and the council approves the amendment, you can continue your work. If your plans change significantly or you find yourself not being able to finish the grant, we can mutually agree to terminate the grant early. You are always welcome to reapply another time.
-</details>
+
 
 
 
 ## 🚚 Milestone Delivery
 
-<details>
-  <summary><b>How do I submit a milestone?</b></summary>
+### How do I submit a milestone?
 
   For details, please refer to the [milestone delivery guidelines](./milestone-deliverables-guidelines.md) for the respective grants program. Generally speaking, the most important part of a delivery is a list of **the same deliverables listed in the application** with links to their implementation/realisation (ideally pointing to a specific commit or tag, so you can continue working on your repository without messing up your delivery and complicating our evaluation) and any additional notes you might have. The list of deliverables for each of your milestones should be defined in your grant agreement.
-</details>
 
-<details>
-  <summary><b>Can I submit two or more milestones at once?</b></summary>
+
+### Can I submit two or more milestones at once?
 
   You can. However, we strongly encourage you to submit your work in increments (milestones), so that you can be sure we didn’t misunderstand (an aspect of) your application, and you didn't make changes to your plan or delivery that would have required a reevaluation of the application.
-</details>
 
-<details>
-  <summary><b>Can I add a badge to my repo once I’ve completed a milestone?</b></summary>
+
+### Can I add a badge to my repo once I’ve completed a milestone?
 
   If yours is a [Level 2 or 3](https://github.com/w3f/Grants-Program/blob/master/README.md#level_slider-levels) grant and your first milestone has been submitted **and accepted**, yes. Please make sure that you follow the [badge guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/grant-badge-guidelines.md) when doing so.
-</details>
 
-<details>
-  <summary><b>Why are other milestones being accepted or discussed faster than mine?</b></summary>
+
+### Why are other milestones being accepted or discussed faster than mine?
 
   While we try to process deliveries chronologically, some milestones aren't processed quite as fast as others. One obvious reason is the complexity of the delivery and its evaluation. Other times, your submission might require internal discussion or delegation. In any case, if you have any question on the processing of your delivery, you can reach out to us via email or Github.
-</details>
+


### PR DESCRIPTION
This replaces the `<details>` tags with headers with anchors, so we can now link to a specific FAQ.