### PR TITLE
Workflow fix for files with spaces

### DIFF
--- a/.github/workflows/application_accepted.yml
+++ b/.github/workflows/application_accepted.yml
@@ -22,6 +22,7 @@ jobs:
         uses: Ana06/get-changed-files@v2.0.0
         with:
           filter: 'applications/*.md'
+          format: 'csv'
 
   update_google_sheet:
     needs: get_filename


### PR DESCRIPTION
Fixes workflow to be able to deal with filenames with spaces.

By default, files changed as reported by `Ana06/get-changed-files@v2.0.0` are space-delimited, so it throws an error when there's a space in the file. Setting the output type as csv gets rid of the error, while still making sure the rest of the workflow works (keeping the previously held assumption that there's only on application file).

See an [example run](https://github.com/lucasvanmol/Grants-Program/actions/runs/2608496099) with this change from this [example pr](https://github.com/lucasvanmol/Grants-Program/pull/4). (The run fails at the google sheets update step because it isn't configured for the fork, but the file is parsed correctly).
