### PR TITLE
Update status badge action to v1.1

### DIFF
--- a/.github/workflows/status_badges.yml
+++ b/.github/workflows/status_badges.yml
@@ -2,12 +2,6 @@ name: Update Status Badges
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches:
-      - '*'
-      - '!master'
-    paths:
-      - 'docs/polkadot_stack.md'
   workflow_dispatch:
 
 jobs:
@@ -18,8 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check and update badges
-        uses: lucasvanmol/status-badges@v1
+        uses: lucasvanmol/status-badges@v1.1
         with:
           path: 'docs/polkadot_stack.md'
           token: ${{ secrets.GITHUB_TOKEN }}
           find-all-links: true
+          pull-request: true


### PR DESCRIPTION
Added ability for the action to create it's own PRs instead of committing directly to the main branch. If the PR doesn't get merged right away, it'll keep force pushing to it's own branch (`status-badges/update` by default) whenever a badge needs to be updated. The branch itself is created by the action, so it can be deleted e.g. when merging.

The action will also abort & fail when the rate limit is reached instead of overwriting existing badges.

Example of a PR issued by the action: https://github.com/lucasvanmol/Grants-Program/pull/6  