### PR TITLE
Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,21 @@
-### Project Abstract
+#### Project Abstract
 
-> Please provide a brief description of your project here summarising key points (1-2 paragraphs).
+> Please replace these instructions with a brief description of your project summarising key points (1-2 paragraphs).
 >
 > If your application is a follow-up to a previous grant, please mention which one in the first line of the abstract and include a link to previous pull requests if applicable.
 
-### For which grant [level](https://github.com/w3f/Grants-Program#level_slider-levels) are you applying?
+#### Grant [level](https://github.com/w3f/Grants-Program#level_slider-levels)
 
 - [ ] **Level 1**:  Up to $10,000, 2 approvals
 - [ ] **Level 2**:  Up to $30,000, 3 approvals
 - [ ] **Level 3**:  Unlimited, 5 approvals (for >$100k: Web3 Foundation Council approval)
 
-### Application Checklist
+#### Application Checklist
 
-- [x] The [application template](https://github.com/w3f/Grants-Program/blob/master/applications/application-template.md) has been copied, renamed ( `project_name.md`) and updated.
-- [ ] I have read and understood the [FAQs](https://github.com/w3f/Grants-Program/blob/master/docs/faq.md), [application guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/grant_guidelines_per_category.md) and [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/announcement-guidelines.md).
+- [x] The [application template](https://github.com/w3f/Grants-Program/blob/master/applications/application-template.md) has been copied and aptly renamed (`project_name.md`).
+- [ ] I have read the [application guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/grant_guidelines_per_category.md).
 - [ ] A BTC, Ethereum (USDT/USDC/DAI) or Polkadot/Kusama (aUSD) address for the payment of the milestones is provided inside the application.
-- [ ] I have read and acknowledge the [terms and conditions](https://github.com/w3f/Grants-Program/blob/master/docs/T&Cs.md).
 - [ ] The software delivered for this grant will be released under an open-source license specified in the application.
 - [ ] The initial PR contains only one commit (squash and force-push if needed).
-- [ ] The grant will only be announced once the first milestone [has been accepted](https://github.com/w3f/Grant-Milestone-Delivery#process).
-- [ ] I prefer the discussion of this application to be in a private Element/Matrix channel. My username is: ``@_______``
-
-### How Did You Hear About our grants program?
-
-- [ ] Social Media
-- [ ] Hackathon
-- [ ] Personal Recommendation
-- [ ] Substrate Builders Program
-- [ ] Investor/VC
-- [ ] Online Search
-- [ ] Other: _______
+- [ ] The grant will only be announced once the first milestone [has been accepted](https://github.com/w3f/Grant-Milestone-Delivery#process) (see the [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/announcement-guidelines.md)).
+- [ ] I prefer the discussion of this application to take place in a private Element/Matrix channel. My username is: `@_______:matrix.org` (change the homeserver if you use a different one)


### PR DESCRIPTION
- FAQ shouldn't be mandatory
- We have the CLA bot for the T&C's
- The announcement guidelines are shared again in the approval comment, and there is already a checkmark for not announcing before the first milestone
- Added default homeserver since many people don't know what it is
- We already ask where they heard about us in the template, if we do want to have it here we can remove it there instead