### PR TITLE
Amend the project milestone tasks

### DIFF
--- a/applications/wasmedge_substrate.md
+++ b/applications/wasmedge_substrate.md
@@ -127,11 +127,10 @@ https://github.com/ParaState/substrate-ssvm-node
 | 0d.    | Docker          | Create Docker images with all build dependencies to faciliate the build process |
 | 0e.    | Article         | Create a blog article to annouce Substrate's option to use WasmEdge |
 | 1.     | Software        | Create configuration options to select between wasmtime and WasmEdge host wrappers. The option will allow the compiler / build system to choose between the wasmtime and wasmedge executors when building the substrate binary. |
-| 2.     | Upstream PR     | Create and merge a PR for the Substrate project. Work with the Substrate team to make sure that the PR is up to the coding standard and testing requirements for Substrate to merge it. |
 
 ### Milestone 3 -- Performance benchmarks and analysis
 
-- Estimated duration: 1 month
+- Estimated duration: 2 month
 - FTE: 2
 - Costs: 15,000 USD
 
@@ -145,6 +144,7 @@ https://github.com/ParaState/substrate-ssvm-node
 | 1.     | Config          | Make sure that AOT is enabled for WasmEdge |
 | 2.     | Eval            | Create performance metrics Substrate integration tests for wasmtime vs WasmEdge, as well as WasmEdge interpreter vs AOT |
 | 3.     | Eval            | Identify performance bottlenecks in Substrate WasmEdge for future actions |
+| 4.     | Upstream PR     | Create and merge a PR for the Substrate project. Work with the Substrate team to make sure that the PR is up to the coding standard and testing requirements for Substrate to merge it. |
 
 
 ## Future Plans


### PR DESCRIPTION
We will need a solid rationale to merge WasmEdge support upstream into the official Substrate repo. So, we changed the order of tasks to complete the performance eval first and then to propose a merge PR. That means shifting the PR task from milestone 2 to 3.

We have also found that the Substrate approach of using host functions requires a lot of changes in the WasmEdge Rust SDK. That has caused a delay and extra engineering work for the project (already completed). We will keep the total project budget the same, but respectfully ask for each milestone payment to stay the same to account for the extra work needed for milestone 2.

Signed-off-by: Michael Yuan <michael@secondstate.io>


#### Grant [level](https://github.com/w3f/Grants-Program#level_slider-levels)

- [ ] **Level 1**:  Up to $10,000, 2 approvals
- [ ] **Level 2**:  Up to $30,000, 3 approvals
- [x] **Level 3**:  Unlimited, 5 approvals (for >$100k: Web3 Foundation Council approval)

https://github.com/w3f/Grants-Program/pull/862