### PR TITLE
Amendment: no fuzzing in wasm-opt-for-rust

### DIFF
--- a/applications/wasm-opt-for-rust.md
+++ b/applications/wasm-opt-for-rust.md
@@ -101,7 +101,12 @@ We will also deliver the following:
   - `cargo-contract`, the ink! build tool
 - One blog post about the tool and its development, at https://brson.github.io
 
+We will not include the following `wasm-opt` capabilities in the library bindings:
 
+- Fuzzing. `wasm-opt` has multiple options related to fuzz testing the output
+  module. We are aware of no potential clients for this feature. Including these
+  fuzzing features requires code duplication in Rust, for additional maintenance
+  burden and questionable benefit.
 
 
 ### Ecosystem Fit


### PR DESCRIPTION
#### Project Abstract

This is a minor amendment to the `wasm-opt-for-rust` grant, which explicitly states that fuzz-testing capabilities are out of scope. The subject was not mentioned in the original application.

Fuzz testing of output is a feature of the underlying tool. It is not used by any known prospective clients, and is probably mostly useful to the the Binaryen project themselves for verifying that the optimizer works correctly.

As [discussed in the M1 review](https://github.com/w3f/Grant-Milestone-Delivery/pull/552#issuecomment-1230409728).

Functionally this project is all but complete. Integration with `cargo-contract` and Substrate `wasm-builder` has begun. The biggest task remaining is to publish a blog post.

https://github.com/w3f/Grants-Program/pull/1070