### PR TITLE
Amendment to wasm-opt-for-rust: no ARM Mac CI

### DIFF
--- a/applications/wasm-opt-for-rust.md
+++ b/applications/wasm-opt-for-rust.md
@@ -90,7 +90,6 @@ We will also deliver the following:
 - Full README and API documentation
 - Basic regression tests for the binary and library
 - CI for the platforms
-  - `aarch64-apple-darwin`
   - `aarch64-unknown-linux-gnu`
   - `i686-pc-windows-msvc`
   - `i686-unknown-linux-gnu`


### PR DESCRIPTION
This is one final amendment to the wasm-opt-for-rust grant.

We promised CI for ARM Macs, and at this time I don't think it is feasible. GitHub does not provide it, Circle CI and Travis don't provide it. The only way to do it (that I have found) is to rent a dedicated cloud M1 mac and set it up to hook into GitHub actions. It's not practical for us.

We have many other CI configurations though, including ARM Linux. I don't have any reason to believe the lack of ARM Mac coverage is going to be a serious problem.

This project is all but done. Resolving this ARM Mac CI issue is one of the very last steps.

#### Application Checklist

- [x] The [application template](https://github.com/w3f/Grants-Program/blob/master/applications/application-template.md) has been copied and aptly renamed (`project_name.md`).
- [x] I have read the [application guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/grant_guidelines_per_category.md).
- [x] A BTC, Ethereum (USDT/USDC/DAI) or Polkadot/Kusama (aUSD) address for the payment of the milestones is provided inside the application.
- [x] The software delivered for this grant will be released under an open-source license specified in the application.
- [x] The initial PR contains only one commit (squash and force-push if needed).
- [x] The grant will only be announced once the first milestone [has been accepted](https://github.com/w3f/Grant-Milestone-Delivery#process) (see the [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/announcement-guidelines.md)).
- [ ] I prefer the discussion of this application to take place in a private Element/Matrix channel. My username is: `@_______:matrix.org` (change the homeserver if you use a different one)
