### PR TITLE
Meta Defender - changed delivery schedule 

### DIFF
--- a/applications/Meta_Defender.md
+++ b/applications/Meta_Defender.md
@@ -320,7 +320,7 @@ Angie: Angie is a Data Scientist in a ASX-listed Fintech in Australia. She has e
 
 ### Milestone 1 — Basic Functionalities
 
-- **Estimated Duration:** 4 months
+- **Estimated Duration:** 5.5 months
 - **FTE:**  2
 - **Costs:** 4,000 USD
 
@@ -335,7 +335,7 @@ Angie: Angie is a Data Scientist in a ASX-listed Fintech in Australia. She has e
 
 ### Milestone 2 Substrate + XCM
 
-- **Estimated Duration:** 4 months
+- **Estimated Duration:** 5 months
 - **FTE:**  2
 - **Costs:** 4,000 USD
 


### PR DESCRIPTION
Hi committee,

Meta Defender has completed the ink! contract and successfully run it in contract-ui([code](https://github.com/327istesting/meta-defender-ink)). During the few months, ink! has a major update from v3 to v4 with lots of changes. We managed to finish the contract with complete business logics, but we would like to amend the delivery schedule because of:

1. It seems that polkadot-js is not compatible with ink! version 4.0.0-beta, we have opened an issue with polkadot-js [here](https://github.com/polkadot-js/apps/issues/8500). We wrote a simple [frond-end demo](https://github.com/327istesting/substrate-ui) but because of the bug there will be errors interacting with the chain. This stops us from completing the second deliverable of first milestone.
2. In the Meta Defender contract logic, an external Erc20 contract is needed for financial purpose. The ink! contract has updated with an ink_e2e testing framework recently which looks practicable for cross-contract testing, however, it didn't come with a documentation and we encounter few obstacles. We have been positively seeking help from ink! develop team and we need more time to pick it up.

Given above, Meta Defender would like amend the proposal with a updated delivery schedule.