### PR TITLE
Change polkadotjs hardware wallet grant address

### DIFF
--- a/applications/polkadotjs-hardware.md
+++ b/applications/polkadotjs-hardware.md
@@ -1,7 +1,7 @@
 # Hardware ECDSA for Polkadot JS
 
 * **Proposer:** @akru
-* **Payment Address:** 146iwtFpePG4GqBfNpMTDRgqfwNjj248JpvDKLyFPM1KSsa (Kusama)
+* **Payment Address:** Ekf4HssuTpYjmUEvzy9AAFuqpUcNm9AAkrMF1stTU6Mo1hR (Kusama)
 
 ## Project Description :page_facing_up: 
 


### PR DESCRIPTION
Due to an internal miscommunication, the original payment address was incorrect.
I updated the grant application to reflect the correct address. Apologies for the confusion.