### PR TITLE
Create stale_checker.yml

### DIFF
--- a/.github/workflows/stale_checker.yml
+++ b/.github/workflows/stale_checker.yml
@@ -1,0 +1,25 @@
+name: Stale checker
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # run at 7:00 UTC every day
+  workflow_dispatch:
+
+jobs:
+  mark_as_stale:
+    if:  github.repository_owner == 'w3f'
+    runs-on: ubuntu-latest
+    steps:
+    - id: stale
+      uses: 0xCaso/label-stale-pull-requests@v1
+      with:
+        context: ${{ toJSON(github) }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - if: steps.stale.outputs.message != ''
+      uses: fadenb/matrix-chat-message@v0.0.6
+      with:
+        homeserver: 'matrix.web3.foundation'
+        token: ${{ secrets.MATRIX_TOKEN }}
+        channel: ${{ secrets.MATRIX_CHANNEL_ID }}
+        message: |
+          ${{ steps.stale.outputs.message }}


### PR DESCRIPTION
The action checks every day at 7:00 UTC if the pull requests are on stale (>=14 days of inactivity). If yes, they get labeled, and a report is sent to the Matrix channel.

See the action repo: https://github.com/0xCaso/label-stale-pull-requests/
