### PR TITLE
Fix link in application_accepted.yml

### DIFF
--- a/.github/workflows/application_accepted.yml
+++ b/.github/workflows/application_accepted.yml
@@ -114,7 +114,7 @@ jobs:
             [support section of our README](https://github.com/w3f/Grants-Program/blob/master/README.md#support)
             for more ways to find answers to your questions. <br/><br/>
             Before you start, take a moment to read through our
-            [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/announcement-guidelines.md)
+            [announcement guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/Support%20Docs/announcement-guidelines.md)
             for all communications related to the grant or make them known to the right person in your organisation.
             In particular, please <b>don't announce the grant publicly before at least the first milestone of your
             project has been approved.</b> At that point or shortly before, you can get in touch with us at


### PR DESCRIPTION
As accidentally spotted when clicking on links in the bot's comment. Wonder if there might be a way to quickly search the whole repo for outdated links :thinking: