### PR TITLE
Add application parser action

### DIFF
--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -1,0 +1,35 @@
+name: Check application document
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  get_filename:
+    if: contains(github.event.pull_request.body, 'Project Abstract')
+    runs-on: ubuntu-latest
+    outputs:
+      filename: ${{ steps.files.outputs.added }}
+    steps:
+
+      - name: Get application filename # We assume there's only one
+        id: 'files'
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          filter: 'applications/*.md'
+          format: 'csv'
+
+  parse_document:
+    needs: get_filename
+    if: needs.get_filename.outputs.filename
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Parse application file
+        id: grant_parser
+        uses: w3f/parse-grant-application-action@master
+        with:
+          path: "${{ github.workspace }}/${{ needs.get_filename.outputs.filename }}"


### PR DESCRIPTION
The action will return error if one (or more) of the following fields is missing: `team_name`, `project_name`, `contact_name`, `contact_email`, `total_cost_dai`, `(registration) address`, `level`, and if it has no milestones (refer to https://github.com/w3f/parse-grant-application-action)