### PR TITLE
Update check_application_document.yml

### DIFF
--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -3,7 +3,7 @@ name: Check application document
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
   get_filename:


### PR DESCRIPTION
Without `edited`, this workflow won't run if the grantees push other things (and, if it was failing, the following pushes won't because the check won't run)