### PR TITLE
Fix discussion_private job

### DIFF
--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -10,11 +10,12 @@ jobs:
     if: |
       ${{ 
         github.event.action == 'opened' &&
-        github.event.pull_request.body &&
-        contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
-        (
-          contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&
-          !contains(github.event.pull_request.body, '@_______:matrix.org')
+        github.event.pull_request.body && (
+          contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
+          (
+            contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&
+            !contains(github.event.pull_request.body, '@_______:matrix.org')
+          )
         )
       }} 
     runs-on: ubuntu-latest

--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -11,7 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add 'discussion private' label if the application is private
-        if: ${{ !contains(github.event.pull_request.body, '- [ ] I prefer the discussion') || !contains(github.event.pull_request.body, '@_______:matrix.org') }}
+        if: |
+          ${{ 
+            contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
+            (
+              contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&
+              !contains(github.event.pull_request.body, '@_______:matrix.org')
+            )
+          }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - name: Add 'discussion private' label if the application is private
         if: |
-          ${{ 
+          ${{
+            github.event.pull_request.body &&
             contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
             (
               contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&

--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -7,19 +7,19 @@ on:
 
 jobs:
   discussion_private:
-    if: ${{ github.event.action == 'opened' }} 
+    if: |
+      ${{ 
+        github.event.action == 'opened' &&
+        github.event.pull_request.body &&
+        contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
+        (
+          contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&
+          !contains(github.event.pull_request.body, '@_______:matrix.org')
+        )
+      }} 
     runs-on: ubuntu-latest
     steps:
       - name: Add 'discussion private' label if the application is private
-        if: |
-          ${{
-            github.event.pull_request.body &&
-            contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
-            (
-              contains(github.event.pull_request.body, '- [ ] I prefer the discussion') &&
-              !contains(github.event.pull_request.body, '@_______:matrix.org')
-            )
-          }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/check_application_document.yml
+++ b/.github/workflows/check_application_document.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   discussion_private:
     if: |
-      ${{ 
         github.event.action == 'opened' &&
         github.event.pull_request.body && (
           contains(github.event.pull_request.body, '- [x] I prefer the discussion') || 
@@ -17,7 +16,6 @@ jobs:
             !contains(github.event.pull_request.body, '@_______:matrix.org')
           )
         )
-      }} 
     runs-on: ubuntu-latest
     steps:
       - name: Add 'discussion private' label if the application is private


### PR DESCRIPTION
Fix checks for `discussion_private` job. 

It assumes that a grantee won't remove the string `@_______:matrix.org` if he doesn't check `- [ ] I prefer the discussion`. See lines 15-16.