### PR TITLE
Amend tokenomics-survey-2022: Remove Dockerfile references

### DIFF
--- a/applications/tokenomics-survey-2022.md
+++ b/applications/tokenomics-survey-2022.md
@@ -239,7 +239,7 @@ Initial flow-chart/decision-tree development that will help developers place the
 | **0a.** | Copyright and Licenses | Creative Commons Attribution 4.0 International License (article), Dual Apache 2 or MIT License (code) |
 | **0b.** | Documentation/Tutorial | We will provide both **artifacts documentation** of the deliverables and a basic **tutorial** that explains how a user can (for example) execute the code included or can visualize data or use any artifacts included. |
 | **0c.** | Methodology | Detailed explanation of how the results were achieved and how to reproduce/verify the results. |
-| **0d.** | Infrastructure | We will provide the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production and Docker files for software execution. |
+| **0d.** | Infrastructure | We will provide the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production. |
 | **0e.** | Article | We create a **draft article** (with source code), in the English language. There will be an acknowledgement "This work was supported by a research grant from the Web3 Foundation. The analysis and opinions expressed are the authors and do not reflect the opinions of the Web3 Foundation." |
 | **0e.1**   |  - Appendix: Methodology    | As described in the methodology section above |
 | **0e.2**   |  - Section: Polkadot Parachains      | Initial Parachain summary |
@@ -258,7 +258,7 @@ Initial flow-chart/decision-tree development that will help developers place the
 | **0a.** | Copyright and Licenses | Creative Commons Attribution 4.0 International License (article), Dual Apache 2 or MIT License (code) |
 | **0b.** | Documentation/Tutorial | We will update both **artifacts documentation** of the deliverables and a basic **tutorial** that explains how a user can (for example) execute the code included or can visualize data or use any artifacts included. |
 | **0c.** | Methodology | Update the detailed explanation of how the results were achieved and how to reproduce/verify the results. |
-| **0d.** | Infrastructure | We will update the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production and Docker files for software execution. |
+| **0d.** | Infrastructure | We will update the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production. |
 | **0e.** | Article | We will send a **draft article** (with source code), in the English language. There will be an acknowledgement "This work was supported by a research grant from the Web3 Foundation. The analysis and opinions expressed are the authors and do not reflect the opinions of the Web3 Foundation."|
 | **0e.1**    | Article                   | We will publish an **working paper** as indicated above. |
 | **0e.2**   |  - Section: Published models    | Initial annotated bibliography |
@@ -288,7 +288,7 @@ The report/working paper will be posted to [SSRN (e.g. FEN - Cryptocurrency Rese
 | **0a.** | Copyright and Licenses | Creative Commons Attribution 4.0 International License (article), Dual Apache 2 or MIT License (code) |
 | **0b.** | Documentation/Tutorial | We will update both **artifacts documentation** of the deliverables and a basic **tutorial** that explains how a user can (for example) execute the code included or can visualize data or use any artifacts included. |
 | **0c.** | Methodology | Update the detailed explanation of how the results were achieved and how to reproduce/verify the results. |
-| **0d.** | Infrastructure | We will update the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production and Docker files for software execution. |
+| **0d.** | Infrastructure | We will update the list of all infrastructure requirements (text editors with proper versions, software packages, data packages, etc) that can be used to verify the deliveries with this milestone. LaTeX for article production. |
 | **0e** | Article | We will update a **draft article** (with source code), in the English language. There will be an acknowledgement "This work was supported by a research grant from the Web3 Foundation. The analysis and opinions expressed are the authors and do not reflect the opinions of the Web3 Foundation."|
 | **0e.1**   |  - Section: Introduction           | Place the topic in perspective and motivate non-specialist readers.  Text and tables where relevant/appropriate. |
 | **0e.2**   |  - Section: Published models    | Update annotated bibliography |


### PR DESCRIPTION
As requested in the milestone review:

https://github.com/w3f/Grant-Milestone-Delivery/blob/master/evaluations/tokenomics-survey-2022_3_takahser.md#general-notes

The project uses Overleaf to produce the document.
