### PR TITLE
ZkWasm Rollup Grant Amendment

### DIFF
--- a/applications/zkwasm-rollups-transfer.md
+++ b/applications/zkwasm-rollups-transfer.md
@@ -134,13 +134,13 @@ In `Milestone 1`, we are going to implement `RedDSA`, optimize `Jubjub` curve an
 | 2. | `Jubjub` curve optimization | `Jubjub` curve optimization allows us to perform elliptic curve arithmetic quickly. In our scheme, zero-knowledge prover time is latency when users send transaction and verification time is gas cost on chain. Specifically, we implement [Twisted Edwards Curves Revisited](https://iacr.org/archive/asiacrypt2008/53500329/53500329.pdf), [Jacobian Coordinates](https://eprint.iacr.org/2014/1014.pdf) and [wNAF](https://www.scitepress.org/papers/2014/50587/50587.pdf), [pippenger](https://cr.yp.to/papers/pippenger.pdf). |
 |3. | Client wallet implementation |We are going to implement client wallet of `RedDSA`. With this wallet, user can generate private key and one time signing key, and delegate their proof generation, in addition to normal wallet functionalities through RPC.|
 
-### Milestone 2 | Plonk Extension
+### Milestone 2 | Nova Folding Recursive Snarks Pallet
 
 - **Estimated duration:** 3 month
 - **FTE:**  2
 - **Costs:** 10,000 USDT
 
-In `Milestone 2`, we are going to implement `plookup` and recursion on top of [plonk](https://github.com/zero-network/dusk-plonk). These can improve the performance and prove the validity of several circuits separatelly.
+In `Milestone 2`, we are going to implement [Nova folding scheme](https://eprint.iacr.org/2021/370.pdf) which allows light weight recursive Snarks.
 
 | Number | Deliverable | Specification |
 | -----: | ----------- | ------------- |
@@ -149,60 +149,19 @@ In `Milestone 2`, we are going to implement `plookup` and recursion on top of [p
 | 0c. | Testing Guide | Core functions will be fully covered by unit tests to ensure functionality and robustness. In the guide, we will describe how to run these tests. |
 | 0d. | Docker | We will provide Dockerfiles that can be used to test all the functionality delivered with this milestone. |
 | 0e. | Article | We will publish an article/tutorial/workshop that explains |
-| 1. | `plookup` implementation | We are going to implement `plookup` to our [plonk](https://github.com/zero-network/dusk-plonk). `plookup` allows us to use precomputed lookup table in zero knowledge circuit and reduce complexity of circuit.|
-| 2. | `recursive proof` implementation | We are going to implement `recursive proof` to our [plonk](https://github.com/zero-network/dusk-plonk). `recursive proof` allows us to generate aggregation circuit and bundle **wasm** ISA proofs to one.|
-| 3. | circuit implementation | We are going to implement zero knowledge circuit which supports combination of `plookup` and `recursive proof`. This circuit allows us to implement the circuit for **zkwasm**.|
-
-### Milestone 3 | Zk Wasm Transfer Prover and Verifier
-
-- **Estimated duration:** 1.5 month
-- **FTE:**  2
-- **Costs:** 10,000 USDT
-
-In `Milestone 3`, we are going to implement `plookup` and `recursive proof` on top of [plonk](https://github.com/zero-network/dusk-plonk). These can improve the performance and prove the validity of several circuits separatelly.
-
-| Number | Deliverable | Specification |
-| -----: | ----------- | ------------- |
-| 0a. | License | Apache 2.0 |
-| 0b. | Documentation | We will provide both `inline documentation` of the code and a `basic tutorial` that explains how users prove the validity of **wasm** ISA execution. |
-| 0c. | Testing Guide | Core functions will be fully covered by unit tests to ensure functionality and robustness. In the guide, we will describe how to run these tests. |
-| 0d. | Docker | We will provide Dockerfiles that can be used to test all the functionality delivered with this milestone. |
-| 0e. | Article | We will publish an article/tutorial/workshop that explains |
-| 1. | **wasm** circuit implementation | We are going to implement zero knowledge circuit for **wasm** ISA. The transfer transaction consists of **wasm** ISA. We divide it into read and write access to each resource and prove with `plookup` and `recursive proof`.|
-| 2. | proof generator implementation | We are going to implement proof generator which generates the proof for **wasm** ISA. The input is execution trace of **wasm** ISA and output is zero knowledge proof. This is implemented on off-chain.|
-| 3. | proof verification implementation | We are going to implement proof verification function which verifies the proof. This is implemented on on-chain.|
-
-### Milestone 4 | Zk Wasm Transfer Rollup Node
-
-- **Estimated duration:** 1.5 month
-- **FTE:**  2
-- **Costs:** 10,000 USDT
-
-In `Milestone 4`, we are going to implement rollup node. This can aggregate transfer transactions and generate proof.
-
-| Number | Deliverable | Specification |
-| -----: | ----------- | ------------- |
-| 0a. | License | Apache 2.0 |
-| 0b. | Documentation | We will provide both `inline documentation` of the code and a `basic tutorial` that explains how users setup the node and send transfer transactions. |
-| 0c. | Testing Guide | Core functions will be fully covered by unit tests to ensure functionality and robustness. In the guide, we will describe how to run these tests. |
-| 0d. | Docker | We will provide Dockerfiles that can be used to test all the functionality delivered with this milestone. |
-| 0e. | Article | We will publish an article/tutorial/workshop that explains |
-| 1. | rollup node implementation | We are going to implement rollup node. This allows to setup the execution environment of L2 transfer transactions, generate the proof and commit the state to mainchain.|
-| 2. | client transactor implementation | We are going to implement client library to request transfer transactions to rollup node. This is the combination of Redsa wallet and proof generator. |
-| 3. | integrate network | We are going to integrate network. There are four actor mainchain, rollup node and transactor, prover. The transactor generates the transaction and delegate proof generation to prover. The prover generates proof and send it back to transactor. The transactor send transaction to rollup node. The rollup node aggregates these transaction and commit the state to mainchain. |
+| 1. | `pasta` implementation | We are going to implement fully Polkadot compatible `pasta` curve for efficient verifier encoder by [cycle of curves](https://eprint.iacr.org/2023/969.pdf).|
+| 2. | `recursive proof` implementation | We are going to implement `recursive proof` with Nova folding scheme. `recursive proof` allows us to compress multiple statements to prove.|
+| 3. | `Nova pallet` implementation | We are going to implement `Nova folding pallet`. `Nova folding pallet` allows us to verify Nova recursive proof which proves multiple statements with a single proof.|
 
 ## Timeline
 
 | Milestone | Deliverable | Estimated Duration (month) | Deadline |
 | -----: | ----------- | ------------- | ------------- |
 | 1 | Crypto Primitive                     |  2  | 2023 7/31 |
-| 2 | Plonk Extension                      |  3  | 2023 10/31 |
-| 3 | Zk Wasm Transfer Prover and Verifier | 1.5 | 2023 12/14 |
-| 4 | Zk Wasm Transfer Rollup Node         | 1.5 | 2024 1/31 |
+| 2 | Nova Folding                         |  3  | 2023 11/30 |
 
 ## Future Plans
 
-- Fully zkwasm rollup
 - Proof for XCMP
 - FHE
 - Verifiable hardware

--- a/applications/zkwasm-rollups-transfer.md
+++ b/applications/zkwasm-rollups-transfer.md
@@ -150,8 +150,9 @@ In `Milestone 2`, we are going to implement [Nova folding scheme](https://eprint
 | 0d. | Docker | We will provide Dockerfiles that can be used to test all the functionality delivered with this milestone. |
 | 0e. | Article | We will publish an article/tutorial/workshop that explains |
 | 1. | `pasta` implementation | We are going to implement fully Polkadot compatible `pasta` curve for efficient verifier encoder by [cycle of curves](https://eprint.iacr.org/2023/969.pdf).|
-| 2. | `recursive proof` implementation | We are going to implement `recursive proof` with Nova folding scheme. `recursive proof` allows us to compress multiple statements to prove.|
-| 3. | `Nova pallet` implementation | We are going to implement `Nova folding pallet`. `Nova folding pallet` allows us to verify Nova recursive proof which proves multiple statements with a single proof.|
+| 2. | `groth16` implementation | We are going to implement fully Polkadot compatible `groth16` for recursive Snarks verifier circuit.|
+| 3. | `recursive proof` implementation | We are going to implement `recursive proof` with Nova folding scheme. `recursive proof` allows us to compress multiple statements to prove.|
+| 4. | `Nova pallet` implementation | We are going to implement `Nova folding pallet`. `Nova folding pallet` allows us to verify Nova recursive proof which proves multiple statements with a single proof.|
 
 ## Timeline
 


### PR DESCRIPTION
Hi there

We would like to amend our grants.
The main changes are as follows.

- Implement Nova folding instead of Plonk
- Remove Zkwasm Rollup

We tried to estimate how the ZkWasm Rollup reduces gas costs by benchmarking a similar scheme ZkRollup in advance.
However, the overhead was larger than the reduced computation amount by Rollup.

## Rollup
Rollup is a technology to collect a bunch of transactions on an off-chain single node and applies the changes on the on-chain. The off-chain computation is executed by a single node but zero knowledge proof causes overhead during proof generation.

The on-chain computation is executed by network participating nodes and the Polkadot has about 297 nodes.
https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.polkadot.io#/staking

If the zero-knowledge overhead is more than 297 times the computation amount than usual execution, Rollup wouldn't work as a scaling solution.

Benchmark results suggested that zero-knowledge proof caused a million to a hundred million overhead than normal execution. Moreover, the Polkadot has a significant [scaling roadmap](https://www.polkadot.network/blog/elevating-polkadots-performance-and-scale-with-asynchronous-backing#asynchronous-backing-in-polkadot%E2%80%99s-broader-scaling-roadmap) including coretime. We think the Polkadot is already scalable so we should focus on extending functionalities with zero knowledge.
## Nova
We did some research about the latest zero-knowledge proof to reduce the cost of Rollup or support new blockchain functionalities as follows.
[Brief Introduction of Latest Zero Knowledge Proof such as ZKVM, Recursion and Lookup](https://medium.com/coinmonks/brief-introduction-of-latest-zero-knowledge-proof-such-as-zkvm-recursion-and-lookup-9cbc60215a47)


As a conclusion, the Rollup is not reasonable even if we use the latest zero knowledge scheme because we need to pay [other costs](https://medium.com/coinmonks/brief-introduction-of-latest-zero-knowledge-proof-such-as-zkvm-recursion-and-lookup-9cbc60215a47#d316) for ZKVM such as security, development cost and so on. We think it’s better to use zero-knowledge for extending blockchain functionalities instead of scaling.


We would like to support Recursive Snarks with Nova folding. Nova folding is the latest zero-knowledge proof and far more efficient than Plonk that we supported. There is no Polkadot compatible Recursive Snarks pallet thus it’s beneficial for the community to support it. It can use zero-knowledge proof with cheap cost and help to extend blockchain functionality.


We did experiment implementation as follows.
https://github.com/ashWhiteHat/nova
## Milestones
In recursive Snarks, provers generate the proof for proof recursively on an off-chain and need to verify the validity of the process on zero knowledge circuit. Proving and verification are done in different fields and it causes 100 times overhead. To avoid that overhead, we are going to support a curve which supports the cycle of curves.

To verify the off-chain verifier circuit, we are going to implement Groth16. And finally, we are going to implement Nova folding pallet and allow developers to use recursive Snarks on the Substrate.

Really sorry for the amendment and inconvenience.
I would appreciate it if you could confirm.