### PR TITLE
Change payment method for SpellRouter

### DIFF
--- a/applications/SpellRouter-proposal.md
+++ b/applications/SpellRouter-proposal.md
@@ -1,7 +1,7 @@
 # SpellRouter - XCM Router by ParaSpell✨
 
 - **Team Name:** ParaSpell✨
-- **Payment Address:** bc1qa7m3f5cm5pcyh7m8f899kx59m93w496ld8nyux BTC
+- **Payment Address:** FIAT (Shared 22.Dec.2023 14:56 via contact email mentioned in the application)
 - **[Level](https://github.com/w3f/Grants-Program/tree/master#level_slider-levels):** 2 🐤
 
 ## Project Overview :page_facing_up:


### PR DESCRIPTION
As we were informed, that a change of payment method is possible we would like to request a change.
The payment details were sent to grants@web3.foundation via email mentioned in application (dudo.morhac@gmail.com).

With kind regards,
Team ParaSpell


