### PR TITLE
vested DOT paid to Polkadot, not AssetHub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 - [x] The [application template](https://github.com/w3f/Grants-Program/blob/master/applications/application-template.md) has been copied and aptly renamed (`project_name.md`).
 - [ ] I have read the [application guidelines](https://github.com/w3f/Grants-Program/blob/master/docs/Support%20Docs/grant_guidelines_per_category.md).
 - [ ] Payment details have been provided (Polkadot AssetHub (DOT, USDC & USDT) address in the application and bank details via email, if applicable).
-- [ ] I understand that 30% of each milestone will be paid in vested DOT, to the Polkadot AssetHub address listed in the application.
+- [ ] I understand that 30% of each milestone will be paid in vested DOT, to the Polkadot address listed in the application.
 - [ ] I am aware that, in order to receive a grant, I (and the entity I represent) have to successfully complete a KYC/KYB check.
 - [ ] The software delivered for this grant will be released under an open-source license specified in the application.
 - [ ] The initial PR contains only one commit (squash and force-push if needed).


### PR DESCRIPTION
Cleaning up the template after legal seems to only be able to pay vested DOT to Polkadot native addresses in order for the funds to remain eligible for staking. 

Line 17 should also somehow include that it's necessary to list a Polkadot address in the application. Suggestions welcome :)